### PR TITLE
Intermediate representation rework.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRCS
     intermediate_representation/segment.pb.cc
     intermediate_representation/space.pb.cc
     intermediate_representation/street.pb.cc
+    intermediate_representation/traffic_way.pb.cc
     procedural/probing/flow/flow.cpp
     procedural/probing/flow/simulate.cpp
     procedural/probing/flow/time_cost.cpp

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,8 @@ done
 popd
 
 # Tests Python modules.
-python3 -m intermediate_representation.catmul_rom_test
-python3 -m procedural.probing.population_test
-python3 -m procedural.street.curve_test
-python3 -m procedural.street.intersection_area_test
-python3 -m procedural.street.ir_street_test
+echo "intermediate_representation.catmul_rom_test" && python3 -m intermediate_representation.catmul_rom_test
+echo "procedural.probing.population_test" && python3 -m procedural.probing.population_test
+echo "procedural.street.curve_test" && python3 -m procedural.street.curve_test
+echo "procedural.street.intersection_area_test" && python3 -m procedural.street.intersection_area_test
+echo "procedural.street.ir_traffic_way_test" && python3 -m procedural.street.ir_traffic_way_test

--- a/intermediate_representation/city.proto
+++ b/intermediate_representation/city.proto
@@ -19,9 +19,17 @@ syntax = "proto3";
 package e8;
 
 import "intermediate_representation/intersection.proto";
+import "intermediate_representation/street.proto";
+import "intermediate_representation/traffic_way.proto";
 
-// For storing all elements in a city.
+// For storing all the elements in a city.
 message City {
-    // Street intersections in the city.
-    repeated StandardIntersection intersections = 1;
+    // Traffic ways, keyed by their unique ID.
+    map<string, TrafficWay> traffic_ways = 1;
+
+    // Streets, keyed by their unique ID.
+    map<string, Street> streets = 2;
+
+    // Street intersections, keyed by their unique ID.
+    map<string, Intersection> intersections = 3;
 }

--- a/intermediate_representation/intersection.proto
+++ b/intermediate_representation/intersection.proto
@@ -18,10 +18,9 @@ syntax = "proto3";
 
 package e8;
 
-import "intermediate_representation/compass.proto";
+import "intermediate_representation/curve.proto";
 import "intermediate_representation/segment.proto";
 import "intermediate_representation/space.proto";
-import "intermediate_representation/street.proto";
 
 // Stores the information about one of the extremities of a street.
 message StreetCut {
@@ -51,19 +50,40 @@ message StreetCut {
     bool unprotected_right_turn = 8;
 }
 
+// Represents the connectivities between the inbound and outbound traffic.
+message TrafficConnection {
+    // The inbound traffic way from which the intersection connects.
+    string inbound_traffic_way_id = 1;
+
+    // The zero-indexed lane number from which the intersection connects.
+    int32 lane_number = 2;
+
+    // The outbound traffic way to which the intersection connnects.
+    string outbound_traffic_way_id = 3;
+}
+
 // Represents a standard street intersection. A standard intersection has
 // streets connecting directly towards the center of the intersection.
 message StandardIntersection {
     // The center location of the intersection.
     Point3 center = 1;
 
-    // The streets which connect towards the center, in counter clock-wise order.
-    repeated Street streets = 2;
-
     // The information which tells how each street is connected to the
-    // intersection.
-    repeated StreetCut street_cuts = 3;
+    // intersection. The corresponding streets are in counter-clockwise order.
+    repeated StreetCut street_cuts = 2;
 
-    // The compass direction of each connected street.
-    repeated CompassDirection street_directions = 4;
+    // The geometry of the boundary which connects from street_cuts[i % len] to
+    // street_cuts[(i + 1) % len].
+    repeated CatmulRomCurve3 boundaries = 3;
+
+    // The connectivities between the inbound and outbound traffic.
+    repeated TrafficConnection connections = 4;
+}
+
+// Encapsulates different types of intersection.
+message Intersection {
+    oneof intersection {
+        // Represents a standard streeet intersection.
+        StandardIntersection standard = 1;
+    }
 }

--- a/intermediate_representation/street.proto
+++ b/intermediate_representation/street.proto
@@ -20,81 +20,6 @@ package e8;
 
 import "intermediate_representation/curve.proto";
 
-// Represents the traffic markings on a street.
-message TrafficMarking {
-    // All available traffic marking types.
-    enum MarkingType {
-        STREET_MARKING_TYPE_UNKNOWN = 0;
-        ARROW_STRAIGHT = 1;
-        ARROW_STRAIGHT_OR_LEFT_TURN = 2;
-        ARROW_STRAIGHT_OR_RIGHT_TURN = 3;
-        ARROW_LEFT_TURN = 4;
-        ARROW_LEFT_TURN_OR_U_TURN = 5;
-        ARROW_RIGHT_TURN = 6;
-        DASHED_WHITE = 7;
-        HOLLOW = 8;
-        SOLID_WHITE = 9;
-        SOLID_YELLOW = 10;
-    }
-
-    // The curve segment for which to apply the marking.
-    ArcInterval arc_interval = 1;
-
-    // The type of traffic marking to apply.
-    MarkingType marking_type = 2;
-}
-
-// Represents a curve with traffic markings.
-message MarkedCurve {
-    // The curve to be marked.
-    CatmulRomCurve3 curve = 1;
-
-    // The markings to apply to different partitions of the curve.
-    repeated TrafficMarking markings = 2;
-}
-
-// Represents a traffic lane.
-message TrafficLane {
-    // Index to TrafficWay::marked_curves, indicating the leftmost boundary of
-    // the traffic lane.
-    int32 left_curve_index = 1;
-
-    // Index to TrafficWay::marked_curves, indicating the rightmost boundary of
-    // the traffic lane.
-    int32 right_curve_index = 2;
-
-    // A list of segments on the left curve which allows legal lane change to
-    // the left adjacent lane.
-    repeated ArcInterval left_lane_change_windows = 3;
-
-    // A list of segments on the right curve which allows legal lane change to
-    // the right adjacent lane.
-    repeated ArcInterval right_lane_change_windows = 4;
-
-    // A list of left adjacent lanes corresponding to the
-    // left_lane_change_windows.
-    repeated TrafficLane left_adjacent_lanes = 5;
-
-    // A list of right adjacent lanes corresponding to the
-    // right_lane_change_windows.
-    repeated TrafficLane right_adjacent_lanes = 6;
-}
-
-// A traffic way enables the transportation from one end of a street to the
-// other.
-message TrafficWay {
-    // All the marked curves in the traffic way.
-    repeated MarkedCurve marked_curves = 1;
-
-    // All traffic lanes that can be accessed from the beginning of the traffic
-    // way.
-    repeated TrafficLane root_lanes = 2;
-
-    // The flow percentile this traffic way belongs to. It indicates how busy
-    // this traffic way is.
-    float flow_percentile = 3;
-}
-
 // Represents the geometry and the semantics associated with a street.
 message Street {
     // The curve which runs down the center of the street.
@@ -102,5 +27,5 @@ message Street {
 
     // A list of traffic ways in the street. A street can only be one-way or
     // two-way.
-    repeated TrafficWay traffic_ways = 2;
+    repeated string traffic_way_ids = 2;
 }

--- a/intermediate_representation/traffic_way.proto
+++ b/intermediate_representation/traffic_way.proto
@@ -1,0 +1,96 @@
+// e8City
+// Copyright (C) 2023 e8yes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+syntax = "proto3";
+
+package e8;
+
+import "intermediate_representation/curve.proto";
+
+// Represents the traffic markings on a street.
+message TrafficMarking {
+    // All available traffic marking types.
+    enum MarkingType {
+        STREET_MARKING_TYPE_UNKNOWN = 0;
+        ARROW_STRAIGHT = 1;
+        ARROW_STRAIGHT_OR_LEFT_TURN = 2;
+        ARROW_STRAIGHT_OR_RIGHT_TURN = 3;
+        ARROW_LEFT_TURN = 4;
+        ARROW_LEFT_TURN_OR_U_TURN = 5;
+        ARROW_RIGHT_TURN = 6;
+        DASHED_WHITE = 7;
+        HOLLOW = 8;
+        SOLID_WHITE = 9;
+        SOLID_YELLOW = 10;
+    }
+
+    // The curve segment for which to apply the marking.
+    ArcInterval arc_interval = 1;
+
+    // The type of traffic marking to apply.
+    MarkingType marking_type = 2;
+}
+
+// Represents a curve with traffic markings.
+message MarkedCurve {
+    // The curve to be marked.
+    CatmulRomCurve3 curve = 1;
+
+    // The markings to apply to different partitions of the curve.
+    repeated TrafficMarking markings = 2;
+}
+
+// Represents a traffic lane.
+message TrafficLane {
+    // Index to TrafficWay::marked_curves, indicating the leftmost boundary of
+    // the traffic lane.
+    int32 left_curve_index = 1;
+
+    // Index to TrafficWay::marked_curves, indicating the rightmost boundary of
+    // the traffic lane.
+    int32 right_curve_index = 2;
+
+    // A list of segments on the left curve which allows legal lane change to
+    // the left adjacent lane.
+    repeated ArcInterval left_lane_change_windows = 3;
+
+    // A list of segments on the right curve which allows legal lane change to
+    // the right adjacent lane.
+    repeated ArcInterval right_lane_change_windows = 4;
+
+    // A list of left adjacent lanes corresponding to the
+    // left_lane_change_windows.
+    repeated TrafficLane left_adjacent_lanes = 5;
+
+    // A list of right adjacent lanes corresponding to the
+    // right_lane_change_windows.
+    repeated TrafficLane right_adjacent_lanes = 6;
+}
+
+// A traffic way enables the transportation from one end of a street to the
+// other.
+message TrafficWay {
+    // All the marked curves in the traffic way.
+    repeated MarkedCurve marked_curves = 1;
+
+    // All traffic lanes that can be accessed from the beginning of the traffic
+    // way.
+    repeated TrafficLane root_lanes = 2;
+
+    // The flow percentile this traffic way belongs to. It indicates how busy
+    // this traffic way is.
+    float flow_percentile = 3;
+}

--- a/procedural/street/ir_traffic_way_test.py
+++ b/procedural/street/ir_traffic_way_test.py
@@ -23,11 +23,12 @@ from sympy import Point2D
 from procedural.probing.flow import ProbeConnectionFlow
 from procedural.probing.population import PopulationProbe
 from procedural.probing.topology import ProbeConnection
-from procedural.street.ir_street import GenerateStreets
+from procedural.street.curve import ComputeStreetCurves
+from procedural.street.ir_traffic_way import GenerateTrafficWays
 
 
-class IrStreetTest(unittest.TestCase):
-    def test_GenerateStreets(self):
+class IrTrafficWayTest(unittest.TestCase):
+    def test_GenerateTrafficWays(self):
         probe0 = PopulationProbe(location=array(
             [0, 0, 0]), population_grid_200=100)
         probe1 = PopulationProbe(location=array(
@@ -41,15 +42,18 @@ class IrStreetTest(unittest.TestCase):
         flow1 = ProbeConnectionFlow(
             src_probe_index=1, dst_probe_index=0, flow=40, lane_count=2)
 
-        streets = GenerateStreets(
+        street_curves = ComputeStreetCurves(
             probes=[probe0, probe1],
             intersection_areas=[intersection0, intersection1],
             connection_flows=[flow0, flow1])
 
+        traffic_ways = GenerateTrafficWays(street_curves)
+
+        self.assertEqual(len(traffic_ways), 2)
         self.assertTrue(ProbeConnection(
-            src_probe_index=0, dst_probe_index=1) in streets)
+            src_probe_index=0, dst_probe_index=1) in traffic_ways)
         self.assertTrue(ProbeConnection(
-            src_probe_index=1, dst_probe_index=0) not in streets)
+            src_probe_index=1, dst_probe_index=0) in traffic_ways)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Separates traffic way out from the street definition.
2. Sepecifies the traffic way connectivities at each intersection.